### PR TITLE
fix: ensure top path and header content are reset during page navigation

### DIFF
--- a/frontend/pages/Dashboard.jsx
+++ b/frontend/pages/Dashboard.jsx
@@ -142,10 +142,6 @@ function CollapsedNavGroupFlyout({ item, childActive, activeNav, setActiveNav, s
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState({ top: 0, left: 0 });
 
-  useEffect(() => {
-    setHeaderExtra(null);
-  }, [activeNav]);
-
   useLayoutEffect(() => {
     if (!open || !wrapRef.current) return;
     const el = wrapRef.current;
@@ -275,6 +271,10 @@ export default function Dashboard() {
     setActiveNavRaw(id);
     localStorage.setItem("nav-active", id);
   };
+
+  useEffect(() => {
+    setHeaderExtra(null);
+  }, [activeNav]);
 
   const setNavGroupOpen = (updater) => {
     setNavGroupOpenRaw((prev) => {


### PR DESCRIPTION
This PR implements a fix to reset the `headerExtra` state in the `Dashboard` component whenever a navigation event occurs (i.e., `activeNav` changes). 

Previously, some pages might leave breadcrumbs or extra header content visible after switching to another page. By moving the reset logic into a `useEffect` hook in the main `Dashboard` component, we ensure that the top path is consistently cleared upon every page transition.

Key changes:
- Removed local header reset from `CollapsedNavGroupFlyout`.
- - Added a global header reset in `Dashboard.jsx` triggered by `activeNav` changes.
Note: No documentation changes are included in this PR as requested.