### PR TITLE
[codex] Backport cost page interaction fixes to 1.0.4

### DIFF
--- a/frontend/pages/LlmCost.jsx
+++ b/frontend/pages/LlmCost.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, Fragment } from "react";
 import intl from "react-intl-universal";
 import LoadingSpinner from "../components/LoadingSpinner.jsx";
 import CostTimeRangeFilter, {
@@ -11,19 +11,62 @@ import { sortCostRows } from "../utils/costTableSort.js";
 import SortableTableTh from "../components/SortableTableTh.jsx";
 import TablePagination, { DEFAULT_TABLE_PAGE_SIZE } from "../components/TablePagination.jsx";
 
-export default function LlmCost() {
+function Sparkline({ data }) {
+  if (!data || data.length === 0) return <div className="h-4 w-20 bg-gray-50 dark:bg-gray-900/40 rounded" />;
+  const max = Math.max(...data, 1);
+  return (
+    <div className="flex h-6 items-end gap-0.5">
+      {data.map((v, i) => (
+        <div
+          key={i}
+          className="w-1.5 rounded-t-sm bg-primary/40 transition-all duration-300 hover:bg-primary"
+          style={{ height: `${Math.max((v / max) * 100, 10)}%` }}
+          title={String(v)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function IOBar({ input, output }) {
+  const total = input + output;
+  if (total === 0) return <div className="h-1.5 w-24 rounded-full bg-gray-100 dark:bg-gray-800" />;
+  const inPct = Math.round((input / total) * 100);
+  const outPct = 100 - inPct;
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex h-1.5 w-24 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+        <div className="h-full bg-primary/80" style={{ width: `${inPct}%` }} />
+        <div className="h-full bg-emerald-400/80" style={{ width: `${outPct}%` }} />
+      </div>
+      <span className="font-mono text-[10px] text-gray-500">{inPct}/{outPct}</span>
+    </div>
+  );
+}
+
+function ErrorRate({ rate }) {
+  const r = parseFloat(rate);
+  const isErr = r > 1.0;
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className={`h-2 w-2 rounded-full ${isErr ? "bg-rose-500 animate-pulse" : "bg-emerald-500"}`} />
+      <span className={`font-medium ${isErr ? "text-rose-600 dark:text-rose-400" : "text-gray-700 dark:text-gray-300"}`}>{rate}%</span>
+    </div>
+  );
+}
+
+export default function LlmCost({ params }) {
   const [activeDays, setActiveDays] = useState(30);
-  const rangeObj = useMemo(() => defaultRangeLastDays(activeDays), [activeDays]);
-  const rangeStart = rangeObj.start;
-  const rangeEnd = rangeObj.end;
+  const [range, setRange] = useState(() => defaultRangeLastDays(30));
+  const { start: rangeStart, end: rangeEnd } = range;
   const [sortKey, setSortKey] = useState(null);
   const [sortOrder, setSortOrder] = useState("asc");
   const [page, setPage] = useState(1);
-  const [drillRow, setDrillRow] = useState(null);
   const [rows, setRows] = useState([]);
-  const [legend, setLegend] = useState("");
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState(null);
+  const [searchQuery, setSearchQuery] = useState(params?.modelName ?? "");
+  const [expandedId, setExpandedId] = useState(null);
 
   const pageSize = DEFAULT_TABLE_PAGE_SIZE;
 
@@ -37,7 +80,6 @@ export default function LlmCost() {
     const bounds = rangeValid ? rangeToDayBounds(rangeStart, rangeEnd) : null;
     if (!bounds) {
       setRows([]);
-      setLegend("");
       setErr(null);
       return;
     }
@@ -49,29 +91,21 @@ export default function LlmCost() {
         const qs = new URLSearchParams({
           startDay: bounds.startDay,
           endDay: bounds.endDay,
+          summary: "true",
         });
         const r = await fetch(`/api/llm-cost-detail?${qs}`);
         const text = await r.text();
         if (!r.ok) {
-          let msg = text;
-          try {
-            const j = JSON.parse(text);
-            if (j?.error) msg = j.error;
-          } catch {
-            /* ignore */
-          }
-          throw new Error(msg || `HTTP ${r.status}`);
+          throw new Error(text || `HTTP ${r.status}`);
         }
         const data = JSON.parse(text);
         if (!cancelled) {
           setRows(Array.isArray(data.rows) ? data.rows : []);
-          setLegend(typeof data.legend === "string" ? data.legend : "");
         }
       } catch (e) {
         if (!cancelled) {
           setErr(e instanceof Error ? e.message : String(e));
           setRows([]);
-          setLegend("");
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -82,11 +116,19 @@ export default function LlmCost() {
     };
   }, [rangeStart, rangeEnd, rangeValid]);
 
-  const filtered = useMemo(() => (rangeValid ? rows : []), [rows, rangeValid]);
+  const filtered = useMemo(() => {
+    if (!rangeValid) return [];
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter((r) => 
+      r.model.toLowerCase().includes(q) || 
+      (r.provider && r.provider.toLowerCase().includes(q))
+    );
+  }, [rows, rangeValid, searchQuery]);
 
   const sortedRows = useMemo(() => {
     if (!sortKey) return filtered;
-    return sortCostRows(filtered, sortKey, sortOrder, "llm");
+    return sortCostRows(filtered, sortKey, sortOrder, "llm-summary");
   }, [filtered, sortKey, sortOrder]);
 
   const totalRows = sortedRows.length;
@@ -100,29 +142,7 @@ export default function LlmCost() {
 
   useEffect(() => {
     setPage(1);
-  }, [rangeStart, rangeEnd]);
-
-  useEffect(() => {
-    if (totalRows === 0) {
-      setPage(1);
-      return;
-    }
-    setPage((p) => Math.min(p, totalPages));
-  }, [totalRows, totalPages]);
-
-  const drillItems = useMemo(() => {
-    if (!drillRow?.drill) return [];
-    return Array.isArray(drillRow.drill) ? drillRow.drill : [];
-  }, [drillRow]);
-
-  useEffect(() => {
-    if (!drillRow) return;
-    const onKey = (e) => {
-      if (e.key === "Escape") setDrillRow(null);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [drillRow]);
+  }, [rangeStart, rangeEnd, searchQuery]);
 
   function handleSort(columnKey) {
     setSortKey((prev) => {
@@ -130,7 +150,7 @@ export default function LlmCost() {
         setSortOrder((o) => (o === "asc" ? "desc" : "asc"));
         return prev;
       }
-      setSortOrder("asc");
+      setSortOrder("desc");
       return columnKey;
     });
   }
@@ -138,188 +158,265 @@ export default function LlmCost() {
   function handleExportCsv() {
     if (!rangeValid || sortedRows.length === 0) return;
     const headers = [
-      intl.get("llmCost.timeRangeStart"),
-      intl.get("llmCost.timeRangeEnd"),
       intl.get("llmCost.model"),
-      intl.get("llmCost.provider"),
-      intl.get("llmCost.statDate"),
+      intl.get("llmCost.vendor"),
       intl.get("llmCost.tokenConsumption"),
-      intl.get("llmCost.share"),
-      intl.get("llmCost.inputOutput"),
+      intl.get("llmCost.callCount"),
+      intl.get("llmCost.errorRate"),
     ];
     const csvData = sortedRows.map((r) => [
-      rangeStart,
-      rangeEnd,
       r.model,
       r.provider,
-      r.statDate,
-      r.tokens,
-      r.share,
-      r.inputOut,
+      r.totalTokens,
+      r.callCount,
+      r.errorRate,
     ]);
-    downloadCsv(filenameWithTime("llm_cost"), headers, csvData);
+    downloadCsv(filenameWithTime("llm_cost_summary"), headers, csvData);
   }
 
   return (
     <div className="space-y-6">
-      {err ? (
-        <div className="rounded-lg border border-rose-200 bg-rose-50/80 px-4 py-3 text-sm text-rose-800 dark:border-rose-900/60 dark:bg-rose-950/40 dark:text-rose-200">
-          {err}
-        </div>
-      ) : null}
-
       <CostTimeRangeFilter
         activeDays={activeDays}
-        onPreset={(p) => setActiveDays(p.days ?? 7)}
+        onPreset={(preset) => {
+          const days = preset?.days ?? preset;
+          setActiveDays(days);
+          setRange(defaultRangeLastDays(days));
+        }}
+        rangeStart={rangeStart}
+        rangeEnd={rangeEnd}
+        onRangeChange={(start, end) => {
+          setActiveDays(null);
+          setRange({ start, end });
+        }}
       />
 
-      <section className="app-card p-4 sm:p-6">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">{intl.get("llmCost.title")}</h2>
+      <section className="app-card overflow-hidden">
+        {/* Header / Search Area */}
+        <div className="border-b border-gray-100 bg-gray-50/30 p-4 dark:border-gray-800 dark:bg-gray-900/20 sm:px-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="relative w-full max-w-md">
+              <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+              </span>
+              <input
+                type="text"
+                placeholder={intl.get("llmCost.searchPlaceholder")}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="app-input w-full py-2 pl-9 pr-3 text-sm focus:ring-2 focus:ring-primary/20"
+              />
+            </div>
+            <button
+              type="button"
+              disabled={!rangeValid || loading || sortedRows.length === 0}
+              onClick={handleExportCsv}
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:border-primary/40 hover:bg-primary-soft hover:text-primary disabled:opacity-40 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a2 2 0 002 2h12a2 2 0 002-2v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              {intl.get("common.exportCsv")}
+            </button>
           </div>
-          <button
-            type="button"
-            disabled={!rangeValid || loading || sortedRows.length === 0}
-            onClick={handleExportCsv}
-            className="shrink-0 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:border-primary/40 hover:bg-primary-soft hover:text-primary disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
-          >
-            {intl.get("common.exportCsv")}
-          </button>
         </div>
-        {loading ? <LoadingSpinner message={intl.get("llmCost.loading")} /> : null}
-        <div className="mt-6 overflow-hidden rounded-lg border border-gray-100 dark:border-gray-800">
+
+        {err && (
+          <div className="mx-6 mt-4 rounded-lg border border-rose-200 bg-rose-50/80 px-4 py-3 text-sm text-rose-800 dark:border-rose-900/60 dark:bg-rose-950/40 dark:text-rose-200">
+            {err}
+          </div>
+        )}
+
+        <div className="relative min-h-[300px] p-0">
+          {loading && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60 dark:bg-gray-950/60">
+              <LoadingSpinner />
+            </div>
+          )}
+
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[880px] border-collapse text-left text-sm">
+            <table className="w-full min-w-[900px] border-collapse text-left text-sm">
               <thead>
-                <tr className="border-b border-gray-100 bg-gray-50/90 dark:border-gray-800 dark:bg-gray-900/50">
-                  <SortableTableTh label={intl.get("llmCost.model")} columnKey="model" sortKey={sortKey} sortOrder={sortOrder} onSort={handleSort} />
-                  <SortableTableTh label="Provider" columnKey="provider" sortKey={sortKey} sortOrder={sortOrder} onSort={handleSort} />
-                  <SortableTableTh label={intl.get("llmCost.statDate")} columnKey="statDate" sortKey={sortKey} sortOrder={sortOrder} onSort={handleSort} />
-                  <SortableTableTh label={intl.get("llmCost.tokenConsumption")} columnKey="tokens" sortKey={sortKey} sortOrder={sortOrder} onSort={handleSort} />
-                  <SortableTableTh label={intl.get("llmCost.share")} columnKey="share" sortKey={sortKey} sortOrder={sortOrder} onSort={handleSort} />
-                  <SortableTableTh label={intl.get("llmCost.inputOutput")} columnKey="inputOut" sortKey={sortKey} sortOrder={sortOrder} onSort={handleSort} />
+                <tr className="border-b border-gray-100 bg-gray-50/50 text-gray-500 dark:text-gray-200 dark:border-gray-800 dark:bg-gray-900/30">
+                  <SortableTableTh label={intl.get("llmCost.model")} columnKey="model" sortKey={sortKey} sortOrder={sortOrder} onSort={handleSort} className="pl-6" />
+                  <SortableTableTh label={intl.get("llmCost.vendor")} columnKey="provider" sortKey={sortKey} sortOrder={sortOrder} onSort={handleSort} />
+                  <SortableTableTh label={intl.get("llmCost.tokenConsumption")} columnKey="totalTokens" sortKey={sortKey} sortOrder={sortOrder} onSort={handleSort} />
+                  <th className="px-4 py-3 font-semibold">{intl.get("llmCost.trend")}</th>
+                  <th className="px-4 py-3 font-semibold">{intl.get("llmCost.ioStructure")}</th>
+                  <SortableTableTh label={intl.get("llmCost.callCount")} columnKey="callCount" sortKey={sortKey} sortOrder={sortOrder} onSort={handleSort} />
+                  <SortableTableTh label={intl.get("llmCost.errorRate")} columnKey="errorRate" sortKey={sortKey} sortOrder={sortOrder} onSort={handleSort} />
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
-                {!rangeValid ? (
+                {pageRows.length === 0 && !loading ? (
                   <tr>
-                    <td colSpan={7} className="px-4 py-12 text-center text-sm text-gray-500">
-                      {intl.get("common.selectTimeRange")}
-                    </td>
-                  </tr>
-                ) : loading ? (
-                  <tr>
-                    <td colSpan={7} className="px-4 py-12 text-center text-sm text-gray-500">
-                      {intl.get("llmCost.loading")}
-                    </td>
-                  </tr>
-                ) : filtered.length === 0 ? (
-                  <tr>
-                    <td colSpan={7} className="px-4 py-12 text-center text-sm text-gray-500">
+                    <td colSpan={7} className="px-6 py-20 text-center text-gray-500">
                       {intl.get("llmCost.noDataInRange")}
                     </td>
                   </tr>
                 ) : (
-                  pageRows.map((row, i) => (
-                    <tr
-                      key={`${row.model}-${row.statDate}-${(safePage - 1) * pageSize + i}`}
-                      role="button"
-                      tabIndex={0}
-                      onClick={() => setDrillRow(row)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          setDrillRow(row);
-                        }
-                      }}
-                      className={[
-                        "cursor-pointer transition-colors duration-200 hover:bg-primary-soft/45 dark:hover:bg-primary/15",
-                        i % 2 === 1 ? "bg-gray-50/50 dark:bg-gray-900/30" : "bg-white dark:bg-gray-950",
-                      ].join(" ")}
-                    >
-                      <td className="px-4 py-3 font-mono text-xs font-medium text-gray-900 dark:text-gray-100">{row.model}</td>
-                      <td className="max-w-[10rem] truncate px-4 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">{row.provider}</td>
-                      <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">{row.statDate}</td>
-                      <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-gray-800 dark:text-gray-200">{row.tokens}</td>
-                      <td className="whitespace-nowrap px-4 py-3 text-gray-600 dark:text-gray-400">{row.share}</td>
-                      <td className="whitespace-nowrap px-4 py-3 text-gray-600 dark:text-gray-400">{row.inputOut}</td>
-                    </tr>
-                  ))
+                  pageRows.map((row) => {
+                    const isExpanded = expandedId === row.model;
+                    return (
+                      <Fragment key={row.model}>
+                        <tr
+                          onClick={() => setExpandedId(isExpanded ? null : row.model)}
+                          className={`group cursor-pointer transition-all hover:bg-gray-50/80 dark:hover:bg-gray-900/40 ${isExpanded ? "bg-primary-soft/50 dark:bg-primary/10 shadow-[inset_0_1px_3px_rgba(0,0,0,0.02)]" : ""}`}
+                        >
+                          <td className={`py-4 pl-6 font-medium text-gray-900 dark:text-gray-100 transition-all ${isExpanded ? "border-l-4 border-primary" : "border-l-4 border-transparent"}`}>
+                            <div className="flex items-center gap-2">
+                              {row.model}
+                              <svg className={`h-3.5 w-3.5 text-gray-400 transition-transform ${isExpanded ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                              </svg>
+                            </div>
+                          </td>
+                          <td className="px-4 py-4 font-mono text-xs text-gray-500 dark:text-gray-400">
+                            <span className="rounded bg-gray-100 px-1.5 py-0.5 dark:bg-gray-800">{row.provider}</span>
+                          </td>
+                          <td className="px-4 py-4 font-mono text-sm font-semibold text-gray-800 dark:text-gray-200">{row.totalTokensFmt}</td>
+                          <td className="px-4 py-4">
+                            <Sparkline data={row.trend} />
+                          </td>
+                          <td className="px-4 py-4">
+                            <IOBar input={row.inputTokens} output={row.outputTokens} />
+                          </td>
+                          <td className="px-4 py-4 font-mono text-xs text-gray-600 dark:text-gray-400">
+                            {row.callCount?.toLocaleString()}
+                          </td>
+                          <td className="px-4 py-4">
+                            <ErrorRate rate={row.errorRate} />
+                          </td>
+                        </tr>
+                        {isExpanded && row.topApps && (
+                          <tr className="bg-primary-soft/50 dark:bg-primary/10 transition-colors">
+                            <td colSpan={7} className={`px-6 py-6 transition-all ${isExpanded ? "border-l-4 border-primary" : "border-l-4 border-transparent"}`}>
+                               <div className="grid grid-cols-1 lg:grid-cols-[1fr_1.2fr_1fr_1.2fr] gap-6">
+                                 {/* Top Apps */}
+                                 <div className="border border-gray-200/60 dark:border-gray-700/60 rounded-xl p-5 bg-white/50 dark:bg-gray-800/30 shadow-sm">
+                                   <h3 className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-4 flex items-center gap-2">
+                                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" /></svg>
+                                     {intl.get("llmCost.topApps")}
+                                   </h3>
+                                   <ul className="space-y-3">
+                                     {row.topApps.map(app => (
+                                       <li key={app.name} className="flex items-center justify-between text-sm">
+                                         <span className="text-gray-700 dark:text-gray-300 flex items-center gap-2">
+                                           <span className="h-1.5 w-1.5 rounded-full bg-primary/60" />
+                                           {app.name}
+                                         </span>
+                                         <span className="font-mono text-primary font-bold">{app.pct}%</span>
+                                       </li>
+                                     ))}
+                                   </ul>
+                                 </div>
+
+                                 {/* Stability */}
+                                 <div className="border border-gray-200/60 dark:border-gray-700/60 rounded-xl p-5 bg-white/50 dark:bg-gray-800/30 shadow-sm">
+                                    <h3 className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-4 flex items-center gap-2">
+                                      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                                      {intl.get("llmCost.stabilityMetrics")}
+                                    </h3>
+                                    <div className="space-y-2">
+                                      <div className="flex items-center justify-between text-sm">
+                                        <span className="text-gray-700 dark:text-gray-300 flex items-center gap-2">
+                                          <span className="h-1.5 w-1.5 rounded-full bg-primary/60" />
+                                          {intl.get("llmCost.avgLatency")}
+                                        </span>
+                                        <span className="font-mono font-bold text-gray-900 dark:text-gray-100">{row.stability?.avgLatency}s</span>
+                                      </div>
+                                      <div className="pt-2">
+                                        <p className="text-[11px] font-bold text-gray-400 mb-2 uppercase tracking-tight flex items-center gap-2">
+                                          <span className="h-1 w-1 rounded-full bg-gray-300" />
+                                          {intl.get("llmCost.errorDist")}
+                                        </p>
+                                        <ul className="space-y-1.5">
+                                          {row.stability?.errorDist?.map(err => (
+                                            <li key={err.code} className="text-[11px] text-gray-500 dark:text-gray-400 flex justify-between bg-gray-50 dark:bg-gray-900/40 px-2 py-1 rounded">
+                                              <span>{err.code}</span>
+                                              <span className="font-medium">{err.count}次</span>
+                                            </li>
+                                          ))}
+                                        </ul>
+                                      </div>
+                                    </div>
+                                 </div>
+
+                                 {/* Efficiency */}
+                                 <div className="border border-gray-200/60 dark:border-gray-700/60 rounded-xl p-5 bg-white/50 dark:bg-gray-800/30 shadow-sm">
+                                    <h3 className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-4 flex items-center gap-2">
+                                      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
+                                      {intl.get("llmCost.efficiencyMetrics")}
+                                    </h3>
+                                    <div className="space-y-3 text-sm">
+                                       <p className="flex justify-between items-center">
+                                         <span className="text-gray-700 dark:text-gray-300 flex items-center gap-2">
+                                           <span className="h-1.5 w-1.5 rounded-full bg-primary/60" />
+                                           {intl.get("llmCost.avgTokensPerSession")}
+                                         </span>
+                                         <span className="font-mono font-bold">{row.efficiency?.avgTokensPerSession}</span>
+                                       </p>
+                                       <p className="flex justify-between items-center">
+                                         <span className="text-gray-700 dark:text-gray-300 flex items-center gap-2">
+                                           <span className="h-1.5 w-1.5 rounded-full bg-primary/60" />
+                                           {intl.get("llmCost.effectiveOutputRate")}
+                                         </span>
+                                         <span className="font-mono font-bold text-emerald-500">{row.efficiency?.effectiveOutputRate}%</span>
+                                       </p>
+                                       <p className="flex justify-between items-center">
+                                         <span className="text-gray-700 dark:text-gray-300 flex items-center gap-2">
+                                           <span className="h-1.5 w-1.5 rounded-full bg-primary/60" />
+                                           {intl.get("llmCost.estMonthlyCost")}
+                                         </span>
+                                         <span className="font-mono font-bold text-primary">{row.efficiency?.estMonthlyCost}</span>
+                                       </p>
+                                    </div>
+                                 </div>
+
+                                 {/* Actions */}
+                                 <div className="flex items-center justify-center border-l border-gray-100 dark:border-gray-800/50 pl-6">
+                                   <button 
+                                     onClick={(e) => {
+                                       e.stopPropagation();
+                                       window.dispatchEvent(new CustomEvent("openclaw-nav", {
+                                         detail: { id: "cost-overview-2", params: { model: row.model } }
+                                       }));
+                                     }}
+                                     className="group flex items-center gap-3 px-6 py-4 rounded-2xl bg-primary/5 text-primary text-sm font-extrabold transition-all hover:bg-primary/10 hover:scale-[1.02] active:scale-[0.98]"
+                                   >
+                                     <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                                     </svg>
+                                     {intl.get("llmCost.viewSessionDetails")}
+                                     <svg className="h-4 w-4 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                                     </svg>
+                                   </button>
+                                 </div>
+                               </div>
+                            </td>
+                          </tr>
+                        )}
+                      </Fragment>
+                    );
+                  })
                 )}
               </tbody>
             </table>
           </div>
         </div>
-        {rangeValid && totalRows > 0 && !loading ? (
+
+        <div className="border-t border-gray-100 p-4 dark:border-gray-800">
           <TablePagination
-            className="mt-6"
             page={safePage}
             pageSize={pageSize}
             total={totalRows}
             onPageChange={setPage}
           />
-        ) : null}
+        </div>
       </section>
-
-      {drillRow && (
-        <>
-          <button
-            type="button"
-            aria-label={intl.get("llmCost.closeDrill")}
-            className="fixed inset-0 z-40 bg-gray-900/40 transition-opacity duration-200"
-            onClick={() => setDrillRow(null)}
-          />
-          <aside className="fixed inset-y-0 right-0 z-50 flex w-full max-w-lg flex-col border-l border-gray-200 bg-white shadow-2xl dark:border-gray-800 dark:bg-gray-950">
-            <div className="flex items-start justify-between gap-4 border-b border-gray-100 px-6 py-4 dark:border-gray-800">
-              <div>
-                <p className="text-xs font-medium uppercase tracking-wide text-gray-400">{intl.get("llmCost.drillTitle")}</p>
-                <p className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">{drillRow.model}</p>
-                <p className="mt-1 font-mono text-xs text-gray-500 dark:text-gray-400">
-                  {intl.get("llmCost.drillInfo", {
-                    statDate: drillRow.statDate,
-                    provider: drillRow.provider,
-                    tokens: drillRow.tokens,
-                  })}
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => setDrillRow(null)}
-                className="rounded-lg p-2 text-gray-500 transition hover:bg-gray-100 hover:text-gray-800 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-                aria-label={intl.get("common.close")}
-              >
-                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto px-6 py-4">
-              <p className="text-sm text-gray-600 dark:text-gray-400">{intl.get("llmCost.drillDesc")}</p>
-              <div className="mt-4 overflow-hidden rounded-lg border border-gray-100 dark:border-gray-800">
-                <table className="w-full border-collapse text-left text-sm">
-                  <thead>
-                    <tr className="border-b border-gray-100 bg-gray-50/90 dark:border-gray-800 dark:bg-gray-900/50">
-                      <th className="px-3 py-2.5 font-semibold text-gray-700 dark:text-gray-300">{intl.get("llmCost.segment")}</th>
-                      <th className="px-3 py-2.5 font-semibold text-gray-700 dark:text-gray-300">Token</th>
-                      <th className="px-3 py-2.5 font-semibold text-gray-700 dark:text-gray-300">{intl.get("llmCost.share")}</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
-                    {drillItems.map((d, idx) => (
-                      <tr key={`${idx}-${d.segment}`} className={idx % 2 === 1 ? "bg-gray-50/50 dark:bg-gray-900/30" : "bg-white dark:bg-gray-950"}>
-                        <td className="px-3 py-2.5 text-gray-800 dark:text-gray-200">{d.segment}</td>
-                        <td className="whitespace-nowrap px-3 py-2.5 font-mono text-xs text-gray-800 dark:text-gray-200">{d.tokens}</td>
-                        <td className="whitespace-nowrap px-3 py-2.5 text-gray-600 dark:text-gray-400">{d.pct}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </aside>
-        </>
-      )}
     </div>
   );
 }

--- a/frontend/utils/costTableSort.js
+++ b/frontend/utils/costTableSort.js
@@ -55,7 +55,7 @@ function compareValues(va, vb) {
  * @param {object[]} rows
  * @param {string} key
  * @param {'asc'|'desc'} order
- * @param {'agent-list'|'llm'} table
+ * @param {'agent-list'|'llm'|'llm-summary'} table
  */
 export function sortCostRows(rows, key, order, table) {
   if (!key || !rows.length) return rows;
@@ -68,6 +68,14 @@ export function sortCostRows(rows, key, order, table) {
           avgPerTask: (r) => parseTokensDisplay(r.avgPerTask),
           callCount: (r) => Number(r.callCount) || 0,
           successRate: (r) => parsePercentDisplay(r.successRate),
+        }[key]
+      : table === "llm-summary"
+      ? {
+          model: (r) => r.model,
+          provider: (r) => r.provider ?? "",
+          totalTokens: (r) => Number(r.totalTokens) || parseTokensDisplay(r.totalTokensFmt),
+          callCount: (r) => Number(r.callCount) || 0,
+          errorRate: (r) => parsePercentDisplay(r.errorRate),
         }[key]
       : {
           model: (r) => r.model,


### PR DESCRIPTION
## Summary
- Backport the optimized model cost detail table experience to release/1.0.4.
- Keep the 1.0.4 time-range filter callback contract compatible with the optimized page.
- Add sorting support for model cost summary fields such as total tokens, call count, and error rate.

## Validation
- npm run build
